### PR TITLE
Simpler duplicateshandler and mergeinterceptor

### DIFF
--- a/Example/Source/Views/TriangleView.swift
+++ b/Example/Source/Views/TriangleView.swift
@@ -118,12 +118,8 @@ public struct TriangleViewStyle: Attributed {
     
     public static var mergeInterceptors: [MergeInterceptor.Type] = []
     
-    public init(_ attributes: [TriangleViewAttribute]) {
+    public init(attributes: [TriangleViewAttribute]) {
         self.attributes = attributes
-    }
-    
-    public init(arrayLiteral elements: TriangleViewAttribute...) {
-        self.attributes = elements
     }
     
     public func install(on styleable: Any) {

--- a/Source/Classes/Attributed/Attributed.swift
+++ b/Source/Classes/Attributed/Attributed.swift
@@ -20,12 +20,8 @@ public protocol AssociatedValueStrippable: Equatable, Comparable {
 
 public typealias AttributeType = AssociatedValueStrippable & AssociatedValueEnumExtractor
 
-/// Type that holds a collection of attributes used to style some `Styleable`. 
-/// This collection can be merged with another instance of it sharing the same `Attribute` associatedtype.
-/// You can also extract values associated to a certain attribute e.g. the `UIColor` associated to the attribute `backgroundColor`.
-public protocol Attributed: Collection, ExpressibleByArrayLiteral, BaseAttributed, CustomStringConvertible {
-    
-    /// `Attribute` type used to style. Needs conformancs to `AssociatedValueStrippable` and `AssociatedValueEnumExtractor` 
+public protocol ExpressibleByAttributes: BaseAttributed {
+    /// `Attribute` type used to style. Needs conformancs to `AssociatedValueStrippable` and `AssociatedValueEnumExtractor`
     /// so that we can perform merging operations and also logic such as `contains:attribute` and `value` extraction,
     /// accessing the value associated to a certain attribute. e.g. the `UIColor` associated to the attribute `backgroundColor`
     associatedtype Attribute: AttributeType
@@ -34,6 +30,12 @@ public protocol Attributed: Collection, ExpressibleByArrayLiteral, BaseAttribute
     
     /// Attributes used to style some `Styleable` type
     var attributes: [Attribute] { get }
+}
+
+/// Type that holds a collection of attributes used to style some `Styleable`. 
+/// This collection can be merged with another instance of it sharing the same `Attribute` associatedtype.
+/// You can also extract values associated to a certain attribute e.g. the `UIColor` associated to the attribute `backgroundColor`.
+public protocol Attributed: ExpressibleByAttributes, Collection, ExpressibleByArrayLiteral, CustomStringConvertible {
     
     /// Needed for conformance to `Collection`
     var startIndex: Int { get }

--- a/Source/Classes/Attributed/Attributed.swift
+++ b/Source/Classes/Attributed/Attributed.swift
@@ -18,6 +18,8 @@ public protocol AssociatedValueStrippable: Equatable, Comparable {
     var stripped: Stripped { get }
 }
 
+public typealias AttributeType = AssociatedValueStrippable & AssociatedValueEnumExtractor
+
 /// Type that holds a collection of attributes used to style some `Styleable`. 
 /// This collection can be merged with another instance of it sharing the same `Attribute` associatedtype.
 /// You can also extract values associated to a certain attribute e.g. the `UIColor` associated to the attribute `backgroundColor`.
@@ -26,7 +28,7 @@ public protocol Attributed: Collection, ExpressibleByArrayLiteral, BaseAttribute
     /// `Attribute` type used to style. Needs conformancs to `AssociatedValueStrippable` and `AssociatedValueEnumExtractor` 
     /// so that we can perform merging operations and also logic such as `contains:attribute` and `value` extraction,
     /// accessing the value associated to a certain attribute. e.g. the `UIColor` associated to the attribute `backgroundColor`
-    associatedtype Attribute: AssociatedValueStrippable, AssociatedValueEnumExtractor
+    associatedtype Attribute: AttributeType
     
     init(attributes: [Attribute])
     

--- a/Source/Classes/Attributed/Attributed.swift
+++ b/Source/Classes/Attributed/Attributed.swift
@@ -32,23 +32,19 @@ public protocol ExpressibleByAttributes: BaseAttributed {
     var attributes: [Attribute] { get }
 }
 
+public protocol AttributesMergable: ExpressibleByAttributes {
+
+    //MARK: - Merging methods
+    func merge(slave: Self, intercept: Bool) -> Self
+}
+
 /// Type that holds a collection of attributes used to style some `Styleable`. 
 /// This collection can be merged with another instance of it sharing the same `Attribute` associatedtype.
 /// You can also extract values associated to a certain attribute e.g. the `UIColor` associated to the attribute `backgroundColor`.
-public protocol Attributed: ExpressibleByAttributes, Collection, ExpressibleByArrayLiteral, CustomStringConvertible {
+public protocol Attributed: AttributesMergable, Collection, ExpressibleByArrayLiteral, CustomStringConvertible {
     
     /// Needed for conformance to `Collection`
     var startIndex: Int { get }
-    
-    //MARK: - Merging methods
-    func merge(slave: Self, intercept: Bool) -> Self
-    func merge(master: Self, intercept: Bool) -> Self
-    
-    func merge(slave: [Attribute], intercept: Bool) -> Self
-    func merge(master: [Attribute], intercept: Bool) -> Self
-    
-    func merge(slave: Attribute, intercept: Bool) -> Self
-    func merge(master: Attribute, intercept: Bool) -> Self
     
     static var mergeInterceptors: [MergeInterceptor.Type] { get set }
     static var duplicatesHandler: AnyDuplicatesHandler<Self>? { get set }
@@ -60,7 +56,7 @@ public protocol Attributed: ExpressibleByAttributes, Collection, ExpressibleByAr
 }
 
 extension Attributed {
-    init(_ attributes: [Attribute]) {
+    public init(_ attributes: [Attribute]) {
         self.init(attributes: Self.removeDuplicatesIfNeededAndAble(attributes))
     }
 }

--- a/Tests/DuplicatesHandlerTests.swift
+++ b/Tests/DuplicatesHandlerTests.swift
@@ -34,7 +34,7 @@ class DuplicatesHandlerTests: BaseXCTest {
 }
 
 struct FoobarViewAttributeDuplicatesHandler: DuplicatesHandler {
-    typealias AttributedType = ViewStyle
+    typealias AttributesExpressible = ViewStyle
     func choseDuplicate(from duplicates: [ViewAttribute]) -> ViewAttribute {
         var foobarAttributes: [FooBarViewAttribute] = []
         for duplicate in duplicates {

--- a/ViewComposer.podspec
+++ b/ViewComposer.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "ViewComposer"
-  s.version      = "0.2.17"
+  s.version      = "0.2.18"
   s.summary      = "Compose views using enums swiftly"
 
   s.description  = <<-DESC


### PR DESCRIPTION
Fixed bug where init(arrayLiteral) was not public, causing Example app to not run.

Began work splitting the protocol `Attributed` into several "layers", in order to simplifying type erasure.
