### PR TITLE
Making UITextField conform to TextHolder

### DIFF
--- a/Source/Classes/ViewAttribute/AttributedValues/TextHolder.swift
+++ b/Source/Classes/ViewAttribute/AttributedValues/TextHolder.swift
@@ -101,6 +101,16 @@ extension UILabel: TextHolder {
     }
 }
 
+extension UITextField: NativeTextColorHolder {}
+extension UITextField: NativeTextAlignmentHolder {}
+extension UITextField: NativeFontHolder {}
+extension UITextField: TextHolder {
+    public var textProxy: String? {
+        get { return text }
+        set { text = newValue }
+    }
+}
+
 extension UITextView: NativeTextColorHolder {}
 extension UITextView: NativeTextAlignmentHolder {}
 extension UITextView: NativeFontHolder {}


### PR DESCRIPTION
This PR will fixes an issue where the `text`, `textAlignment`, `font` and `textColor` properties were ignored when composing views containing an `UITextField`.