### PR TITLE
Made it possible to merge control states

### DIFF
--- a/Source/Classes/ViewAttribute/AttributedValues/ControlState.swift
+++ b/Source/Classes/ViewAttribute/AttributedValues/ControlState.swift
@@ -26,6 +26,10 @@ public class ControlState {
 
 extension ControlState {
     
+    public convenience init() {
+        self.init(borderColor: nil)
+    }
+    
     public convenience init(_ title: String? = nil, _ titleColor: UIColor? = nil, _ image: UIImage? = nil, borderColor: UIColor? = nil) {
         self.init(title: title, titleColor: titleColor, image: image, colorOfBorder: borderColor)
     }
@@ -66,3 +70,68 @@ public class Application: ControlState {
 public class Reserved: ControlState {
     public override var state: UIControlState { return .reserved }
 }
+
+
+extension ControlState: MergeableAttribute {
+    public func merge(overwrittenBy other: ControlState) -> Self {
+        guard state == other.state else { fatalError("Not same UIControlState") }
+        let merged = self
+        merged.title = other.title ?? self.title
+        merged.titleColor = other.titleColor ?? self.titleColor
+        merged.image = other.image ?? self.image
+        merged.borderColor = other.borderColor ?? self.borderColor
+        return merged
+    }
+}
+
+extension UIControlState: Hashable {
+    public var hashValue: Int { return rawValue.hashValue }
+}
+
+extension ControlState: Equatable {
+    public static func == (lhs: ControlState, rhs: ControlState) -> Bool { return lhs.state == rhs.state }
+}
+
+extension ControlState: Hashable {
+    public var hashValue: Int { return state.hashValue }
+}
+
+extension Array where Element == ControlState {
+    public func merge(overwrittenBy other: [ControlState]) -> [ControlState] {
+        
+        let concatenated: [ControlState] = self + other
+        
+        let allTypes: [UIControlState] = concatenated.map { $0.state }
+        let duplicateOfDuplicates = allTypes.filter { (type: UIControlState) in allTypes.filter { $0 == type }.count > 1 }
+        //swiftlint:disable:next syntactic_sugar
+        let duplicateTypes = Array<UIControlState>(Set<UIControlState>(duplicateOfDuplicates))
+        
+        var merged = [ControlState]()
+        
+        for duplicateType in duplicateTypes {
+            let duplicateStates = concatenated.filter { $0.state == duplicateType }
+            var duplicateState = duplicateStates[0]
+            duplicateStates.forEach { duplicateState = duplicateState.merge(overwrittenBy: $0) }
+            merged.append(duplicateState)
+        }
+        
+        var set = Set<ControlState>(merged)
+        concatenated.forEach { set.insert($0) }
+        return Array(set)
+    }
+}
+
+public struct ControlStateMerger: MergeInterceptor {
+    public static func interceptMerge<A>(master masterAttributed: A, slave: A) -> A where A : Attributed {
+        guard
+            let master = masterAttributed as? ViewStyle,
+            let slave = slave as? ViewStyle,
+            let masterControlStates: [ControlState] = master.value(.states),
+            let slaveControlStates: [ControlState] = slave.value(.states)
+            else { return masterAttributed }
+        let merged = slaveControlStates.merge(overwrittenBy: masterControlStates)
+        //swiftlint:disable:next force_cast
+        return ViewStyle([.states(merged)]) as! A
+    }
+}
+

--- a/Source/Classes/ViewAttribute/AttributedValues/MergableAttribute.swift
+++ b/Source/Classes/ViewAttribute/AttributedValues/MergableAttribute.swift
@@ -1,0 +1,13 @@
+//
+//  MergableAttribute.swift
+//  ViewComposer
+//
+//  Created by Alexander Cyon on 2017-08-03.
+//
+//
+
+import Foundation
+
+public protocol MergeableAttribute {
+    func merge(overwrittenBy other: Self) -> Self
+}

--- a/Source/Classes/ViewStyle/ViewStyle.swift
+++ b/Source/Classes/ViewStyle/ViewStyle.swift
@@ -11,7 +11,7 @@ import UIKit
 public struct ViewStyle: Attributed {
     public typealias Attribute = ViewAttribute
     public typealias Element = ViewAttribute
-    public static var mergeInterceptors: [MergeInterceptor.Type] = []
+    public static var mergeInterceptors: [MergeInterceptor.Type] = [ControlStateMerger.self]
     public static var duplicatesHandler: AnyDuplicatesHandler<ViewStyle>?
     public static var customStyler: AnyCustomStyler<ViewStyle>?
     

--- a/Tests/ControlStateMergingTests.swift
+++ b/Tests/ControlStateMergingTests.swift
@@ -1,0 +1,137 @@
+//
+//  ControlStateMergingTests.swift
+//  ViewComposer
+//
+//  Created by Alexander Cyon on 2017-08-03.
+//
+//
+
+//ControlStateMerger.self
+
+import Foundation
+
+import XCTest
+@testable import ViewComposer
+class ControlStateMergingTests: BaseXCTest {
+    
+    func testMergeOfTwoArrayContainingSingleNormalStateHavingTitleAndColor() {
+        let s1: [ControlState] = [Normal(fooText)]
+        let s2: [ControlState] = [Normal(.red)]
+        let merged = s1.merge(overwrittenBy: s2)
+        XCTAssertTrue(merged.count == 1)
+        let mergedState = merged[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: fooText)
+        assertIs(mergedState.titleColor, is: .red)
+    }
+    
+    func testMergeOfArrayNormalStateHavingTextWithArrayWithNormalStateHavingTitleColorAndImageAndBorderColor() {
+        let s1: [ControlState] = [Normal(fooText)]
+        let s2: [ControlState] = [Normal(titleColor: .red, image: image, colorOfBorder: .blue)]
+        let merged = s1.merge(overwrittenBy: s2)
+        XCTAssertTrue(merged.count == 1)
+        let mergedState = merged[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: fooText)
+        assertIs(mergedState.titleColor, is: .red)
+        XCTAssertNotNil(mergedState.image)
+        assertIs(mergedState.borderColor, is: .blue)
+    }
+    
+    func testMergeViewStyleContainingStatesOfArrayNormalStateHavingTextWithArrayWithNormalStateHavingTitleColorAndImageAndBorderColor() {
+        XCTAssertTrue(ViewStyle.mergeInterceptors.count == 0)
+        ViewStyle.mergeInterceptors.append(ControlStateMerger.self)
+        XCTAssertTrue(ViewStyle.mergeInterceptors.count == 1)
+        let c1: [ControlState] = [Normal(fooText)]
+        let c2: [ControlState] = [Normal(titleColor: .red, image: image, colorOfBorder: .blue)]
+        
+        let s1: ViewStyle = [.states(c1)]
+        let s2: ViewStyle = [.states(c2)]
+        
+        let merged = s1.merge(master: s2)
+        XCTAssertTrue(merged.count == 1)
+        guard let mergedStates: [ControlState] = merged.value(.states) else { XCTAssertTrue(false); return }
+        XCTAssertTrue(mergedStates.count == 1)
+        
+        let mergedState = mergedStates[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: fooText)
+        assertIs(mergedState.titleColor, is: .red)
+        XCTAssertNotNil(mergedState.image)
+        assertIs(mergedState.borderColor, is: .blue)
+    }
+    
+    func testMergeOfTwoArrayContainingNormalAndHighlightedStateBothHavingTitleAndColor() {
+        let s1: [ControlState] = [Normal(fooText), Highlighted(.blue)]
+        let s2: [ControlState] = [Highlighted(barText), Normal(.red)]
+        let merged = s1.merge(overwrittenBy: s2)
+        XCTAssertTrue(merged.count == 2)
+        for state in merged {
+            if state.state == .highlighted {
+                assertIs(state.title, is: barText)
+                assertIs(state.titleColor, is: .blue)
+            } else {
+                assertIs(state.state, is: .normal)
+                assertIs(state.title, is: fooText)
+                assertIs(state.titleColor, is: .red)
+            }
+        }
+    }
+    
+    func testMergeOfArrayContainingSingleNormalStateHavingTitleWithArrayContainingSingleNormalStateEmtpy() {
+        let s1: [ControlState] = [Normal(fooText)]
+        let s2: [ControlState] = [Normal()]
+        let merged = s1.merge(overwrittenBy: s2)
+        XCTAssertTrue(merged.count == 1)
+        let mergedState = merged[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: fooText)
+    }
+    
+    func testMergeOfArrayContainingSingleNormalStateHavungTitleWithArrayContainingSingleNormalStateEmtpyInvertedOrder() {
+        let s1: [ControlState] = [Normal(fooText)]
+        let s2: [ControlState] = [Normal()]
+        let merged = s2.merge(overwrittenBy: s1)
+        XCTAssertTrue(merged.count == 1)
+        let mergedState = merged[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: fooText)
+    }
+    
+    func testMergeOfTwoArrayContainingSingleNormalStateHavingTitleConflicting() {
+        let s1: [ControlState] = [Normal(fooText)]
+        let s2: [ControlState] = [Normal(barText)]
+        let merged = s1.merge(overwrittenBy: s2)
+        XCTAssertTrue(merged.count == 1)
+        let mergedState = merged[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: barText)
+    }
+    
+    func testMergeOfTwoArrayContainingSingleNormalStateHavingTitleConflictingInverted() {
+        let s1: [ControlState] = [Normal(fooText)]
+        let s2: [ControlState] = [Normal(barText)]
+        let merged = s2.merge(overwrittenBy: s1)
+        XCTAssertTrue(merged.count == 1)
+        let mergedState = merged[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: fooText)
+    }
+    
+    func testMergeOfArrayContainingSingleNormalStateHavingTitleWithEmptyArray() {
+        let s1: [ControlState] = [Normal(fooText)]
+        let s2 = [ControlState]()
+        let merged = s1.merge(overwrittenBy: s2)
+        XCTAssertTrue(merged.count == 1)
+        let mergedState = merged[0]
+        assertIs(mergedState.state, is: .normal)
+        assertIs(mergedState.title, is: fooText)
+    }
+    
+    func testMergeOfTwoEmptyArrays() {
+        let s1 = [ControlState]()
+        let s2 = [ControlState]()
+        let merged = s1.merge(overwrittenBy: s2)
+        XCTAssertTrue(merged.count == 0)
+    }
+}

--- a/Tests/ProcessControlStatesTests.swift
+++ b/Tests/ProcessControlStatesTests.swift
@@ -6,7 +6,6 @@
 //
 //
 
-
 import Foundation
 
 import XCTest

--- a/ViewComposer.podspec
+++ b/ViewComposer.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "ViewComposer"
-  s.version      = "0.2.24"
+  s.version      = "0.2.25"
   s.summary      = "Compose views using enums swiftly"
 
   s.description  = <<-DESC

--- a/ViewComposer.xcodeproj/project.pbxproj
+++ b/ViewComposer.xcodeproj/project.pbxproj
@@ -110,6 +110,8 @@
 		48D7F3CC1EE4988900BC7012 /* ViewAttribute+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D7F3CB1EE4988900BC7012 /* ViewAttribute+Operators.swift */; };
 		48D7F3CF1EE5444000BC7012 /* MergingViewStyleWithArraysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D7F3CD1EE5443A00BC7012 /* MergingViewStyleWithArraysTests.swift */; };
 		48EF19F91EF129A600E7A10D /* MergeOperatorAssociativityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48EF19F81EF129A600E7A10D /* MergeOperatorAssociativityTests.swift */; };
+		48F3FFB21F33629D005D8FA1 /* ControlStateMergingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F3FFB11F33629D005D8FA1 /* ControlStateMergingTests.swift */; };
+		48F3FFB51F336B12005D8FA1 /* MergableAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48F3FFB31F336B04005D8FA1 /* MergableAttribute.swift */; };
 		48FD21E61F005B0E0074EAAB /* UITableView+ViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FD21E51F005B0E0074EAAB /* UITableView+ViewStyle.swift */; };
 		48FD21E81F005EB90074EAAB /* CollectionTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FD21E71F005EB90074EAAB /* CollectionTableView.swift */; };
 		58A276593784FDED9DBBB41B /* Pods_ViewComposerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 379A92F3B9FFF9572443D16B /* Pods_ViewComposerTests.framework */; };
@@ -237,6 +239,8 @@
 		48D7F3CB1EE4988900BC7012 /* ViewAttribute+Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ViewAttribute+Operators.swift"; sourceTree = "<group>"; };
 		48D7F3CD1EE5443A00BC7012 /* MergingViewStyleWithArraysTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MergingViewStyleWithArraysTests.swift; sourceTree = "<group>"; };
 		48EF19F81EF129A600E7A10D /* MergeOperatorAssociativityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MergeOperatorAssociativityTests.swift; sourceTree = "<group>"; };
+		48F3FFB11F33629D005D8FA1 /* ControlStateMergingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlStateMergingTests.swift; sourceTree = "<group>"; };
+		48F3FFB31F336B04005D8FA1 /* MergableAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MergableAttribute.swift; sourceTree = "<group>"; };
 		48FD21E51F005B0E0074EAAB /* UITableView+ViewStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITableView+ViewStyle.swift"; sourceTree = "<group>"; };
 		48FD21E71F005EB90074EAAB /* CollectionTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionTableView.swift; sourceTree = "<group>"; };
 		4C9A5DF6C0FB4A5BB8B1E1DF /* Pods-ViewComposerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ViewComposerTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ViewComposerTests/Pods-ViewComposerTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -445,6 +449,7 @@
 				485524C21EF074C80002C5D6 /* WebView.swift */,
 				48FD21E71F005EB90074EAAB /* CollectionTableView.swift */,
 				4875EC9A1F0A77CB00A9D680 /* TextInputTraitable.swift */,
+				48F3FFB31F336B04005D8FA1 /* MergableAttribute.swift */,
 			);
 			path = AttributedValues;
 			sourceTree = "<group>";
@@ -549,6 +554,7 @@
 				48247B301F001CC800AF8F0A /* MergeInterceptorsTests.swift */,
 				48247B321F001D3E00AF8F0A /* DuplicatesHandlerTests.swift */,
 				4812E1481F010D38008241F8 /* ProcessControlStatesTests.swift */,
+				48F3FFB11F33629D005D8FA1 /* ControlStateMergingTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -879,6 +885,7 @@
 				484110571EEDA12E0016620B /* CellRegisterable.swift in Sources */,
 				4822A1381EF2909A005B8F77 /* UIScrollView+ViewStyle.swift in Sources */,
 				48298B581EE6B04C00AB3724 /* EmptyInitializable.swift in Sources */,
+				48F3FFB51F336B12005D8FA1 /* MergableAttribute.swift in Sources */,
 				482B896B1EE00C6500C97D42 /* AutoAssociatedValueEnum.generated.swift in Sources */,
 				484110231EEC436E0016620B /* DelegatesOwner.swift in Sources */,
 				484110451EED7C030016620B /* UISegmentedControl+Makeable.swift in Sources */,
@@ -924,6 +931,7 @@
 				48748A821EE5C4A600E937E0 /* MakeableFromStyleTests.swift in Sources */,
 				482B897C1EE00C7100C97D42 /* BaseXCTest.swift in Sources */,
 				4812E1491F010D38008241F8 /* ProcessControlStatesTests.swift in Sources */,
+				48F3FFB21F33629D005D8FA1 /* ControlStateMergingTests.swift in Sources */,
 				48247B311F001CC800AF8F0A /* MergeInterceptorsTests.swift in Sources */,
 				4841F8ED1EE9975C00D80898 /* MergeOfOptionalsUsingOperatorsTests.swift in Sources */,
 				48D7F3CF1EE5444000BC7012 /* MergingViewStyleWithArraysTests.swift in Sources */,


### PR DESCRIPTION
You can now merge ControlStates for you UIControls, e.g Buttons.

Like this:

```swift
let s1: ViewStyle = [.states([Normal("foo", Highlighted("bar"))])]
let s2: ViewStyle = [.states([Normal(.blue)])] // titleColor
guard let controlStates: [ControlState] = (s1 <- s2).value(.states), let normal = controlStates.filter { $0.state == .normal }.first else { return }
print(normal.title!) // prints: "foo"
if normal.titleColor != nil { print("Has titleColor") } // prints: "Has titleColor"
```