### PR TITLE
Bug fix of `placeholder` attribute, adding background on buttons for different states, and more merge operators.

### DIFF
--- a/Example/Source/ViewControllers/ViewComposer/LoginViewController.swift
+++ b/Example/Source/ViewControllers/ViewComposer/LoginViewController.swift
@@ -10,23 +10,26 @@ import UIKit
 import ViewComposer
 
 private let height: CGFloat = 50
-private let style: ViewStyle = [.font(.big), .height(height)]
-private let fieldStyle = style <<- .borderWidth(2)
+private let style: ViewStyle = [.font(.big), .height(height), .clipsToBounds(true) ]
+private let borderStyle = style <<- .borderWidth(2)
 private let borderColorNormal: UIColor = .blue
 
 final class LoginViewController: UIViewController, StackViewOwner {
     
-    lazy var emailField: UITextField = fieldStyle <<- [.placeholder("Email"), .delegate(self)]
-    lazy var passwordField: UITextField = fieldStyle <<- [.placeholder("Password"), .delegate(self)]
+    lazy var emailField: UITextField = borderStyle <<- [.placeholder("Email"), .delegate(self)]
+    lazy var passwordField: UITextField = borderStyle <<- [.placeholder("Password"), .delegate(self)]
     
-    lazy var loginButton: Button = style <<-
-        .states([Normal("Login", .blue, borderColor: borderColorNormal), Highlighted("Logging in...", .red, borderColor: .red)]) <-
-        .target(self.target(#selector(loginButtonPressed))) <-
-       [.color(.green), .cornerRadius(height/2), .borderWidth(2), .borderColor(borderColorNormal)]
+    lazy var loginButton: Button = borderStyle
+        <<- .states([
+            Normal("Login", titleColor: .blue, backgroundColor: .green, borderColor: borderColorNormal),
+            Highlighted("Logging in...", titleColor: .red, backgroundColor: .yellow, borderColor: .red)
+        ])
+        <- .target(self.target(#selector(loginButtonPressed)))
+        <- [.roundedBy(.height)]
     
-    lazy var stackView: UIStackView = .axis(.vertical) <-
-        .views([self.emailField, self.passwordField, self.loginButton]) <-
-        [.spacing(20), .layoutMargins(all: 20), .marginsRelative(true)]
+    var views: [UIView] { return [emailField, passwordField, loginButton] }
+    lazy var stackView: UIStackView = .axis(.vertical) <- .views(self.views)
+        <- [.spacing(20), .layoutMargins(all: 20), .marginsRelative(true)]
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Source/Classes/MergeOperators/MergeOperatorReturningAttributed.swift
+++ b/Source/Classes/MergeOperators/MergeOperatorReturningAttributed.swift
@@ -80,6 +80,17 @@ public func <- <A: Attributed>(lhs: [A.Attribute], rhs: A) -> A {
     return lhs.merge(slave: rhs)
 }
 
+//MARK: RHS `[Attributed.Attribute]`
+// RHS MASTER
+public func <<- <A: Attributed>(lhs: [A.Attribute], rhs: [A.Attribute]) -> A {
+    return lhs.merge(master: A(rhs))
+}
+
+// RHS SLAVE
+public func <- <A: Attributed>(lhs: [A.Attribute], rhs: [A.Attribute]) -> A {
+    return lhs.merge(slave: A(rhs))
+}
+
 //////////////////////////////////////////////////////////
 //MARK: -
 //MARK: LHS: `Attributed.Attribute`

--- a/Source/Classes/MergeOperators/MergeOperatorReturningComposable.swift
+++ b/Source/Classes/MergeOperators/MergeOperatorReturningComposable.swift
@@ -68,6 +68,17 @@ public func <- <A: Attributed, C: Composable>(lhs: [A.Attribute], rhs: A) -> C w
     return C(lhs <- rhs)
 }
 
+//MARK: RHS `[Attributed.Attribute]`
+// RHS MASTER
+public func <<- <A: Attributed, C: Composable>(lhs: [A.Attribute], rhs: [A.Attribute]) -> C where C.Style == A {
+    return C(lhs <<- A(rhs))
+}
+
+// RHS SLAVE
+public func <- <A: Attributed, C: Composable>(lhs: [A.Attribute], rhs: [A.Attribute]) -> C where C.Style == A {
+    return C(lhs <- A(rhs))
+}
+
 ////////////////////////////////////////////////
 //MARK: -
 //MARK: -

--- a/Source/Classes/MergeOperators/MergeOperatorReturningMakable.swift
+++ b/Source/Classes/MergeOperators/MergeOperatorReturningMakable.swift
@@ -68,6 +68,17 @@ public func <- <A: Attributed, M: Makeable>(lhs: [A.Attribute], rhs: A) -> M whe
     return M.make(lhs <- rhs)
 }
 
+//MARK: RHS `[Attributed.Attribute]`
+// RHS MASTER
+public func <<- <A: Attributed, M: Makeable>(lhs: [A.Attribute], rhs: [A.Attribute]) -> M where M.Style == A, M.Styled == M {
+    return M.make(lhs <<- A(rhs))
+}
+
+// RHS SLAVE
+public func <- <A: Attributed, M: Makeable>(lhs: [A.Attribute], rhs: [A.Attribute]) -> M where M.Style == A, M.Styled == M {
+    return M.make(lhs <- A(rhs))
+}
+
 ////////////////////////////////////////////////
 //MARK: -
 //MARK: -

--- a/Source/Classes/ViewAttribute/AttributedValues/ControlState.swift
+++ b/Source/Classes/ViewAttribute/AttributedValues/ControlState.swift
@@ -1,5 +1,5 @@
 //
-//  ControlState.swift
+//  ControlStateStyle.swift
 //  ViewComposer
 //
 //  Created by Alexander Cyon on 2017-05-31.
@@ -8,72 +8,79 @@
 
 import UIKit
 
-public class ControlState {
+public class ControlStateStyle {
     public var state: UIControlState { fatalError("Override me") }
     
     public var title: String?
     public var titleColor: UIColor?
     public var image: UIImage?
     public var borderColor: UIColor?
+    public var backgroundColor: UIColor?
     
-    public init(title: String? = nil, titleColor: UIColor? = nil, image: UIImage? = nil, colorOfBorder borderColor: UIColor? = nil) {
+    public init(
+        _ title: String? = nil,
+        image: UIImage? = nil,
+        titleColor: UIColor? = nil,
+        backgroundColor: UIColor? = nil,
+        borderColor: UIColor? = nil
+    ) {
         self.title = title
         self.titleColor = titleColor
         self.image = image
         self.borderColor = borderColor
+        self.backgroundColor = backgroundColor
     }
 }
 
-extension ControlState {
+extension ControlStateStyle {
     
-    public convenience init() {
-        self.init(borderColor: nil)
+    public convenience init(_ title: String, _ titleColor: UIColor) {
+        self.init(title, titleColor: titleColor)
     }
     
-    public convenience init(_ title: String? = nil, _ titleColor: UIColor? = nil, _ image: UIImage? = nil, borderColor: UIColor? = nil) {
-        self.init(title: title, titleColor: titleColor, image: image, colorOfBorder: borderColor)
+    public convenience init(_ title: String, _ image: UIImage) {
+        self.init(title, image: image)
     }
     
-    public convenience init(_ title: String?, _ image: UIImage?) {
-        self.init(title: title, titleColor: nil, image: image, colorOfBorder: nil)
+    public convenience init(_ title: String, _ image: UIImage, _ titleColor: UIColor) {
+        self.init(title, image: image, titleColor: titleColor)
     }
     
-    public convenience init(_ titleColor: UIColor?) {
-        self.init(title: nil, titleColor: titleColor, image: nil, colorOfBorder: nil)
+    public convenience init(_ titleColor: UIColor) {
+        self.init(titleColor: titleColor)
     }
 }
 
-public class Normal: ControlState {
+public class Normal: ControlStateStyle {
     public override var state: UIControlState { return .normal }
 }
 
-public class Highlighted: ControlState {
+public class Highlighted: ControlStateStyle {
     public override var state: UIControlState { return .highlighted }
 }
 
-public class Disabled: ControlState {
+public class Disabled: ControlStateStyle {
     public override var state: UIControlState { return .disabled }
 }
 
-public class Selected: ControlState {
+public class Selected: ControlStateStyle {
     public override var state: UIControlState { return .selected }
 }
 
-public class Focused: ControlState {
+public class Focused: ControlStateStyle {
     public override var state: UIControlState { return .focused }
 }
 
-public class Application: ControlState {
+public class Application: ControlStateStyle {
     public override var state: UIControlState { return .application }
 }
 
-public class Reserved: ControlState {
+public class Reserved: ControlStateStyle {
     public override var state: UIControlState { return .reserved }
 }
 
-
-extension ControlState: MergeableAttribute {
-    public func merge(overwrittenBy other: ControlState) -> Self {
+extension ControlStateStyle: MergeableAttribute {
+    public func merge(overwrittenBy other: ControlStateStyle) -> Self {
         guard state == other.state else { fatalError("Not same UIControlState") }
         let merged = self
         merged.title = other.title ?? self.title
@@ -88,25 +95,25 @@ extension UIControlState: Hashable {
     public var hashValue: Int { return rawValue.hashValue }
 }
 
-extension ControlState: Equatable {
-    public static func == (lhs: ControlState, rhs: ControlState) -> Bool { return lhs.state == rhs.state }
+extension ControlStateStyle: Equatable {
+    public static func == (lhs: ControlStateStyle, rhs: ControlStateStyle) -> Bool { return lhs.state == rhs.state }
 }
 
-extension ControlState: Hashable {
+extension ControlStateStyle: Hashable {
     public var hashValue: Int { return state.hashValue }
 }
 
-extension Array where Element == ControlState {
-    public func merge(overwrittenBy other: [ControlState]) -> [ControlState] {
+extension Array where Element == ControlStateStyle {
+    public func merge(overwrittenBy other: [ControlStateStyle]) -> [ControlStateStyle] {
         
-        let concatenated: [ControlState] = self + other
+        let concatenated: [ControlStateStyle] = self + other
         
         let allTypes: [UIControlState] = concatenated.map { $0.state }
         let duplicateOfDuplicates = allTypes.filter { (type: UIControlState) in allTypes.filter { $0 == type }.count > 1 }
         //swiftlint:disable:next syntactic_sugar
         let duplicateTypes = Array<UIControlState>(Set<UIControlState>(duplicateOfDuplicates))
         
-        var merged = [ControlState]()
+        var merged = [ControlStateStyle]()
         
         for duplicateType in duplicateTypes {
             let duplicateStates = concatenated.filter { $0.state == duplicateType }
@@ -115,7 +122,7 @@ extension Array where Element == ControlState {
             merged.append(duplicateState)
         }
         
-        var set = Set<ControlState>(merged)
+        var set = Set<ControlStateStyle>(merged)
         concatenated.forEach { set.insert($0) }
         return Array(set)
     }
@@ -126,8 +133,8 @@ public struct ControlStateMerger: MergeInterceptor {
         guard
             let master = masterAttributed as? ViewStyle,
             let slave = slave as? ViewStyle,
-            let masterControlStates: [ControlState] = master.value(.states),
-            let slaveControlStates: [ControlState] = slave.value(.states)
+            let masterControlStates: [ControlStateStyle] = master.value(.states),
+            let slaveControlStates: [ControlStateStyle] = slave.value(.states)
             else { return masterAttributed }
         let merged = slaveControlStates.merge(overwrittenBy: masterControlStates)
         //swiftlint:disable:next force_cast

--- a/Source/Classes/ViewAttribute/AttributedValues/ControlStateHolder.swift
+++ b/Source/Classes/ViewAttribute/AttributedValues/ControlStateHolder.swift
@@ -9,24 +9,32 @@
 import Foundation
 
 public protocol ControlStateHolder {
-    func setControlStates(_ states: [ControlState])
+    func setControlStates(_ states: [ControlStateStyle])
 }
 
 extension UIButton: ControlStateHolder {
-    @nonobjc public func setControlStates(_ states: [ControlState]) {
+    @nonobjc public func setControlStates(_ states: [ControlStateStyle]) {
         ifNeededSetTitleForNonNormalStates(states)
         states.forEach {
             configureControlState($0)
         }
+        ifNeededSetBorderColor(states)
     }
 }
 
 internal extension UIButton {
-    func configureControlState(_ state: ControlState) {
-        setTitle(state.title, for: state.state)
-        setImage(state.image, for: state.state)
-        setTitleColor(state.titleColor, for: state.state)
-        setBorderColor(state.borderColor)
+    func configureControlState(_ style: ControlStateStyle) {
+        let state = style.state
+        // important to call `setBackgroundColor` before `setImage`, since image should override.
+        setBackgroundColor(style.backgroundColor, forState: state)
+        setTitle(style.title, for: state)
+        setTitleColor(style.titleColor, for: state)
+        setImage(style.image, for: state)
+    }
+    
+    func ifNeededSetBorderColor(_ styles: [ControlStateStyle]) {
+        let normal = styles.filter({ $0.state == .normal }).first
+        setBorderColor(normal?.borderColor)
     }
     
     @nonobjc func setBorderColor(_ borderColor: UIColor?) {
@@ -38,12 +46,12 @@ internal extension UIButton {
         layer.borderColor = borderColor
     }
     
-    func ifNeededSetTitleForNonNormalStates(_ states: [ControlState]) {
+    func ifNeededSetTitleForNonNormalStates(_ states: [ControlStateStyle]) {
         guard let title = normalTitle(from: states) else { return }
         states.filter { $0.title == nil }.forEach { $0.title = title }
     }
     
-    func normalTitle(from states: [ControlState]) -> String? {
+    func normalTitle(from states: [ControlStateStyle]) -> String? {
         var normalTitle: String?
         for state in states {
             guard state is Normal else { continue }
@@ -52,4 +60,22 @@ internal extension UIButton {
         return normalTitle
     }
 
+    func setBackgroundColor(_ color: UIColor?, forState state: UIControlState) {
+        guard let color = color else { return }
+        setBackgroundImage(imageWithColor(color), for: state)
+    }
+}
+
+fileprivate func imageWithColor(_ color: UIColor) -> UIImage {
+    let rect = CGRect(x: 0.0, y: 0.0, width: 1.0, height: 1.0)
+    UIGraphicsBeginImageContext(rect.size)
+    let context = UIGraphicsGetCurrentContext()
+    
+    context?.setFillColor(color.cgColor)
+    context?.fill(rect)
+    
+    let image = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    
+    return image!
 }

--- a/Source/Classes/ViewAttribute/AttributedValues/PlaceholderOwner.swift
+++ b/Source/Classes/ViewAttribute/AttributedValues/PlaceholderOwner.swift
@@ -24,3 +24,6 @@ internal extension PlaceholderOwner {
         }
     }
 }
+
+extension UITextField: PlaceholderOwner {}
+extension UISearchBar: PlaceholderOwner {}

--- a/Source/Classes/ViewAttribute/ViewAttribute.swift
+++ b/Source/Classes/ViewAttribute/ViewAttribute.swift
@@ -125,7 +125,7 @@ public enum ViewAttribute {
     case keyboardDismissMode(UIScrollViewKeyboardDismissMode)
     
     //MARK: - UIControl
-    case states([ControlState])
+    case states([ControlStateStyle])
     case contentVerticalAlignment(UIControlContentVerticalAlignment)
     case contentHorizontalAlignment(UIControlContentHorizontalAlignment)
     case targets([Actor])

--- a/Source/Classes/ViewStyle/ViewStyle.swift
+++ b/Source/Classes/ViewStyle/ViewStyle.swift
@@ -29,6 +29,61 @@ public extension ViewStyle {
     func install(on styleable: Any) {
         defer { ViewStyle.customStyler?.customStyle(styleable, with: self) }
         guard let view = styleable as? UIView else { return }
+        
+        // Important to setup shared settings first, so that specific setting may override
+        attributes.forEach {
+            switch $0 {
+            // All UIViews
+            case .custom(let attributed):
+                attributed.install(on: styleable)
+            case .hidden(let isHidden):
+                view.isHidden = isHidden
+            case .layoutMargins(let margin):
+                view.layoutMargins = UIEdgeInsets(top: margin, left: margin, bottom: margin, right: margin)
+            case .color(let color):
+                view.backgroundColor = color
+            case .verticalHugging(let prio):
+                view.setContentHuggingPriority(prio.value, for: .vertical)
+            case .verticalCompression(let prio):
+                view.setContentCompressionResistancePriority(prio.value, for: .vertical)
+            case .horizontalHugging(let prio):
+                view.setContentHuggingPriority(prio.value, for: .horizontal)
+            case .horizontalCompression(let prio):
+                view.setContentCompressionResistancePriority(prio.value, for: .horizontal)
+            case .contentMode(let contentMode):
+                view.contentMode = contentMode
+            case .userInteractable(let isUserInteractionEnabled):
+                view.isUserInteractionEnabled = isUserInteractionEnabled
+            case .tintColor(let tintColor):
+                view.tintColor = tintColor
+            case .clipsToBounds(let clipsToBounds):
+                view.clipsToBounds = clipsToBounds
+            case .alpha(let alpha):
+                view.alpha = alpha
+            case .opaque(let isOpaque):
+                view.isOpaque = isOpaque
+            case .exclusiveTouch(let isExclusiveTouch):
+                view.isExclusiveTouch = isExclusiveTouch
+            case .multipleTouchEnabled(let isMultipleTouchEnabled):
+                view.isMultipleTouchEnabled = isMultipleTouchEnabled
+            case .clearsContextBeforeDrawing(let clearsContextBeforeDrawing):
+                view.clearsContextBeforeDrawing = clearsContextBeforeDrawing
+            case .semanticContentAttribute(let semantic):
+                view.semanticContentAttribute = semantic
+                
+            // Layer
+            case .cornerRadius(let radius):
+                view.layer.cornerRadius = radius
+                view.layer.masksToBounds = radius > 0
+            case .borderWidth(let borderWidth):
+                view.layer.borderWidth = borderWidth
+            case .borderColor(let borderColor):
+                view.layer.borderColor = borderColor.cgColor
+            default:
+                break
+            }
+        }
+        
         if let textHolder = view as? TextHolder {
             textHolder.apply(self)
         }
@@ -141,60 +196,6 @@ public extension ViewStyle {
         
         if let progressView = view as? UIProgressView {
             progressView.apply(self)
-        }
-        
-        // Shared
-        attributes.forEach {
-            switch $0 {
-            // All UIViews
-            case .custom(let attributed):
-                attributed.install(on: styleable)
-            case .hidden(let isHidden):
-                view.isHidden = isHidden
-            case .layoutMargins(let margin):
-                view.layoutMargins = UIEdgeInsets(top: margin, left: margin, bottom: margin, right: margin)
-            case .color(let color):
-                view.backgroundColor = color
-            case .verticalHugging(let prio):
-                view.setContentHuggingPriority(prio.value, for: .vertical)
-            case .verticalCompression(let prio):
-                view.setContentCompressionResistancePriority(prio.value, for: .vertical)
-            case .horizontalHugging(let prio):
-                view.setContentHuggingPriority(prio.value, for: .horizontal)
-            case .horizontalCompression(let prio):
-                view.setContentCompressionResistancePriority(prio.value, for: .horizontal)
-            case .contentMode(let contentMode):
-                view.contentMode = contentMode
-            case .userInteractable(let isUserInteractionEnabled):
-                view.isUserInteractionEnabled = isUserInteractionEnabled
-            case .tintColor(let tintColor):
-                view.tintColor = tintColor
-            case .clipsToBounds(let clipsToBounds):
-                view.clipsToBounds = clipsToBounds
-            case .alpha(let alpha):
-                view.alpha = alpha
-            case .opaque(let isOpaque):
-                view.isOpaque = isOpaque
-            case .exclusiveTouch(let isExclusiveTouch):
-                view.isExclusiveTouch = isExclusiveTouch
-            case .multipleTouchEnabled(let isMultipleTouchEnabled):
-                view.isMultipleTouchEnabled = isMultipleTouchEnabled
-            case .clearsContextBeforeDrawing(let clearsContextBeforeDrawing):
-                view.clearsContextBeforeDrawing = clearsContextBeforeDrawing
-            case .semanticContentAttribute(let semantic):
-                view.semanticContentAttribute = semantic
-            
-                // Layer
-            case .cornerRadius(let radius):
-                view.layer.cornerRadius = radius
-                view.layer.masksToBounds = radius > 0
-            case .borderWidth(let borderWidth):
-                view.layer.borderWidth = borderWidth
-            case .borderColor(let borderColor):
-                view.layer.borderColor = borderColor.cgColor
-            default:
-                break
-            }
         }
     }
 }

--- a/Source/Classes/Views/Makeable/UIButton+Makeable.swift
+++ b/Source/Classes/Views/Makeable/UIButton+Makeable.swift
@@ -13,38 +13,4 @@ extension UIButton: Makeable {
     public static func createEmpty() -> UIButton {
         return UIButton(frame: .zero)
     }
-    
-    public func postMake(_ style: ViewStyle) {
-        ensureCorrectTitle(with: style)
-        ensureCorrectImage(with: style)
-        setBorderColorIfNeeded(with: style)
-    }
-}
-
-private extension UIButton {
-    
-    func ensureCorrectTitle(with style: ViewStyle) {
-        guard
-            style.contains(.text),
-            let states: [ControlState] = style.value(.states)
-            else { return }
-        setControlStates(states)
-    }
-    
-    func ensureCorrectImage(with style: ViewStyle) {
-        guard
-            style.contains(.image),
-            let states: [ControlState] = style.value(.states)
-            else { return }
-        setControlStates(states)
-    }
-    
-    func setBorderColorIfNeeded(with style: ViewStyle) {
-        guard
-            let states: [ControlState] = style.value(.states),
-            let normal = states.filter({ $0.state == .normal }).first,
-            let borderColor = normal.borderColor
-            else { return }
-        layer.borderColor = borderColor.cgColor
-    }
 }

--- a/Source/Composables/Button.swift
+++ b/Source/Composables/Button.swift
@@ -50,12 +50,12 @@ private extension Button {
 }
 
 private extension ViewStyle {
-    func state(with state: UIControlState) -> ControlState? {
-        guard let states: [ControlState] = value(.states) else { return nil }
+    func state(with state: UIControlState) -> ControlStateStyle? {
+        guard let states: [ControlStateStyle] = value(.states) else { return nil }
         return states.filter { $0.state == state }.first
     }
 }
 
 private extension ViewStyle {
-    @nonobjc static let `default`: ViewStyle = [.roundedBy(.height), .verticalHugging(.high), .verticalCompression(.high)]
+    @nonobjc static let `default`: ViewStyle = [.roundedBy(.height), .clipsToBounds(true), .verticalHugging(.high), .verticalCompression(.high)]
 }

--- a/Source/Sourcery/Generated/AutoAssociatedValueEnum.generated.swift
+++ b/Source/Sourcery/Generated/AutoAssociatedValueEnum.generated.swift
@@ -1098,7 +1098,7 @@ extension AssociatedValueStrippable {
                                 return nil
                         }
                     }
-                    var states: [ControlState]? {
+                    var states: [ControlStateStyle]? {
                         switch self {
                             case .states(let states):
                                 return states

--- a/Tests/ControlStateMergingTests.swift
+++ b/Tests/ControlStateMergingTests.swift
@@ -15,8 +15,8 @@ import XCTest
 class ControlStateMergingTests: BaseXCTest {
     
     func testMergeOfTwoArrayContainingSingleNormalStateHavingTitleAndColor() {
-        let s1: [ControlState] = [Normal(fooText)]
-        let s2: [ControlState] = [Normal(.red)]
+        let s1: [ControlStateStyle] = [Normal(fooText)]
+        let s2: [ControlStateStyle] = [Normal(.red)]
         let merged = s1.merge(overwrittenBy: s2)
         XCTAssertTrue(merged.count == 1)
         let mergedState = merged[0]
@@ -26,8 +26,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfArrayNormalStateHavingTextWithArrayWithNormalStateHavingTitleColorAndImageAndBorderColor() {
-        let s1: [ControlState] = [Normal(fooText)]
-        let s2: [ControlState] = [Normal(titleColor: .red, image: image, colorOfBorder: .blue)]
+        let s1: [ControlStateStyle] = [Normal(fooText)]
+        let s2: [ControlStateStyle] = [Normal(image: image, titleColor: .red, borderColor: .blue)]
         let merged = s1.merge(overwrittenBy: s2)
         XCTAssertTrue(merged.count == 1)
         let mergedState = merged[0]
@@ -42,15 +42,15 @@ class ControlStateMergingTests: BaseXCTest {
         XCTAssertTrue(ViewStyle.mergeInterceptors.count == 0)
         ViewStyle.mergeInterceptors.append(ControlStateMerger.self)
         XCTAssertTrue(ViewStyle.mergeInterceptors.count == 1)
-        let c1: [ControlState] = [Normal(fooText)]
-        let c2: [ControlState] = [Normal(titleColor: .red, image: image, colorOfBorder: .blue)]
+        let c1: [ControlStateStyle] = [Normal(fooText)]
+        let c2: [ControlStateStyle] = [Normal(image: image, titleColor: .red, borderColor: .blue)]
         
         let s1: ViewStyle = [.states(c1)]
         let s2: ViewStyle = [.states(c2)]
         
         let merged = s1.merge(master: s2)
         XCTAssertTrue(merged.count == 1)
-        guard let mergedStates: [ControlState] = merged.value(.states) else { XCTAssertTrue(false); return }
+        guard let mergedStates: [ControlStateStyle] = merged.value(.states) else { XCTAssertTrue(false); return }
         XCTAssertTrue(mergedStates.count == 1)
         
         let mergedState = mergedStates[0]
@@ -62,8 +62,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfTwoArrayContainingNormalAndHighlightedStateBothHavingTitleAndColor() {
-        let s1: [ControlState] = [Normal(fooText), Highlighted(.blue)]
-        let s2: [ControlState] = [Highlighted(barText), Normal(.red)]
+        let s1: [ControlStateStyle] = [Normal(fooText), Highlighted(.blue)]
+        let s2: [ControlStateStyle] = [Highlighted(barText), Normal(.red)]
         let merged = s1.merge(overwrittenBy: s2)
         XCTAssertTrue(merged.count == 2)
         for state in merged {
@@ -79,8 +79,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfArrayContainingSingleNormalStateHavingTitleWithArrayContainingSingleNormalStateEmtpy() {
-        let s1: [ControlState] = [Normal(fooText)]
-        let s2: [ControlState] = [Normal()]
+        let s1: [ControlStateStyle] = [Normal(fooText)]
+        let s2: [ControlStateStyle] = [Normal()]
         let merged = s1.merge(overwrittenBy: s2)
         XCTAssertTrue(merged.count == 1)
         let mergedState = merged[0]
@@ -89,8 +89,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfArrayContainingSingleNormalStateHavungTitleWithArrayContainingSingleNormalStateEmtpyInvertedOrder() {
-        let s1: [ControlState] = [Normal(fooText)]
-        let s2: [ControlState] = [Normal()]
+        let s1: [ControlStateStyle] = [Normal(fooText)]
+        let s2: [ControlStateStyle] = [Normal()]
         let merged = s2.merge(overwrittenBy: s1)
         XCTAssertTrue(merged.count == 1)
         let mergedState = merged[0]
@@ -99,8 +99,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfTwoArrayContainingSingleNormalStateHavingTitleConflicting() {
-        let s1: [ControlState] = [Normal(fooText)]
-        let s2: [ControlState] = [Normal(barText)]
+        let s1: [ControlStateStyle] = [Normal(fooText)]
+        let s2: [ControlStateStyle] = [Normal(barText)]
         let merged = s1.merge(overwrittenBy: s2)
         XCTAssertTrue(merged.count == 1)
         let mergedState = merged[0]
@@ -109,8 +109,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfTwoArrayContainingSingleNormalStateHavingTitleConflictingInverted() {
-        let s1: [ControlState] = [Normal(fooText)]
-        let s2: [ControlState] = [Normal(barText)]
+        let s1: [ControlStateStyle] = [Normal(fooText)]
+        let s2: [ControlStateStyle] = [Normal(barText)]
         let merged = s2.merge(overwrittenBy: s1)
         XCTAssertTrue(merged.count == 1)
         let mergedState = merged[0]
@@ -119,8 +119,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfArrayContainingSingleNormalStateHavingTitleWithEmptyArray() {
-        let s1: [ControlState] = [Normal(fooText)]
-        let s2 = [ControlState]()
+        let s1: [ControlStateStyle] = [Normal(fooText)]
+        let s2 = [ControlStateStyle]()
         let merged = s1.merge(overwrittenBy: s2)
         XCTAssertTrue(merged.count == 1)
         let mergedState = merged[0]
@@ -129,8 +129,8 @@ class ControlStateMergingTests: BaseXCTest {
     }
     
     func testMergeOfTwoEmptyArrays() {
-        let s1 = [ControlState]()
-        let s2 = [ControlState]()
+        let s1 = [ControlStateStyle]()
+        let s2 = [ControlStateStyle]()
         let merged = s1.merge(overwrittenBy: s2)
         XCTAssertTrue(merged.count == 0)
     }

--- a/Tests/MakeableFromStyleTests.swift
+++ b/Tests/MakeableFromStyleTests.swift
@@ -38,6 +38,12 @@ class MakeableFromStyleTests: XCTestCase {
         assertIs(label.textAlignment, is: .center)
     }
     
+    func testMakingLabelFromMergeBetweenTwoArrays() {
+        let label: UILabel =  [.text(barText)] <- [.textAlignment(.center)]
+        assertIs(label.text, is: barText)
+        assertIs(label.textAlignment, is: .center)
+    }
+    
     func testMakingButtonFromMergeBetweenStyleAndAttributesArrayOperators() {
         let button: UIButton = style <<- [.text(barText), .textColor(.red)]
         assertIs(button.title(for: .normal), is: barText)

--- a/Tests/MergeInterceptorsTests.swift
+++ b/Tests/MergeInterceptorsTests.swift
@@ -236,11 +236,31 @@ class MergeInterceptorsTests: BaseXCTest {
         XCTAssert(style.value(.foo) == fooText)
     }
     
+    func testMasterMergeOperatorBetweenTwoArrays() {
+        ViewStyle.duplicatesHandler = AnyDuplicatesHandler(FoobarViewAttributeDuplicatesHandler())
+        ViewStyle.mergeInterceptors.append(FooBarViewAttributeMerger.self)
+        let merged: ViewStyle =  [.bar(bar)] <<- [.foo(fooText)]
+        guard let style: FooBarViewStyle = merged.value(.custom) else { XCTAssert(false); return }
+        XCTAssert(style.count == 2)
+        XCTAssert(style.value(.bar) == bar)
+        XCTAssert(style.value(.foo) == fooText)
+    }
+    
     //using slave
     func testSlaveMergeOperatorBetweenSingleAttributes() {
         ViewStyle.duplicatesHandler = AnyDuplicatesHandler(FoobarViewAttributeDuplicatesHandler())
         ViewStyle.mergeInterceptors.append(FooBarViewAttributeMerger.self)
         let merged: ViewStyle =  .bar(bar) <- .foo(fooText)
+        guard let style: FooBarViewStyle = merged.value(.custom) else { XCTAssert(false); return }
+        XCTAssert(style.count == 2)
+        XCTAssert(style.value(.bar) == bar)
+        XCTAssert(style.value(.foo) == fooText)
+    }
+    
+    func testSlaveMergeOperatorBetweenTwoArrays() {
+        ViewStyle.duplicatesHandler = AnyDuplicatesHandler(FoobarViewAttributeDuplicatesHandler())
+        ViewStyle.mergeInterceptors.append(FooBarViewAttributeMerger.self)
+        let merged: ViewStyle =  [.bar(bar)] <- [.foo(fooText)]
         guard let style: FooBarViewStyle = merged.value(.custom) else { XCTAssert(false); return }
         XCTAssert(style.count == 2)
         XCTAssert(style.value(.bar) == bar)

--- a/Tests/MergingViewAttributeArraysTests.swift
+++ b/Tests/MergingViewAttributeArraysTests.swift
@@ -89,6 +89,21 @@ class MergeResultingInAttributeArrayTests: XCTestCase {
         XCTAssert(barMasterUsingMaster.associatedValue(.text) == barText)
     }
     
+    func testMergeArraysByLiteralsOperators() {
+        let fooMasterUsingSlave = [.text(fooText), .color(color)] <- [.text(barText), .hidden(isHidden)]
+        let fooMasterUsingMaster = [.text(barText), .hidden(isHidden)] <<- [.text(fooText), .color(color)]
+        let attrs = [fooMasterUsingSlave, fooMasterUsingMaster]
+        for attributes in attrs {
+            XCTAssert(attributes.count == 3)
+            XCTAssert(type(of: attributes) == ViewStyle.self)
+            XCTAssert(attributes.contains(.color))
+            XCTAssert(attributes.contains(.hidden))
+            XCTAssert(attributes.contains(.text))
+        }
+        XCTAssert(fooMasterUsingSlave.associatedValue(.text) == fooText)
+        XCTAssert(fooMasterUsingMaster.associatedValue(.text) == fooText)
+    }
+    
     func testMergeArraysTwoDoublets() {
         let fooAttr: [ViewAttribute] = [.text(fooText), .cornerRadius(fooRadius)]
         let barAttr: [ViewAttribute] = [.text(barText), .cornerRadius(barRadius)]

--- a/Tests/ProcessControlStatesTests.swift
+++ b/Tests/ProcessControlStatesTests.swift
@@ -20,7 +20,7 @@ class ProcessControlStatesTests: BaseXCTest {
         let colorFocused: UIColor = .cyan
         let colorApplication: UIColor = .purple
         let colorReserved: UIColor = .orange
-        let states: [ControlState] = [
+        let states: [ControlStateStyle] = [
             Normal(fooText, colorNormal),
             Highlighted(colorHighlighted),
             Disabled(colorDisabled),
@@ -53,57 +53,58 @@ class ProcessControlStatesTests: BaseXCTest {
     }
     
     func testControlStateInitializerTitleOnly() {
-        let controlState = Normal(fooText)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(fooText)
+        assertButton(with: controlStateStyle)
     }
     
     func testControlStateInitializerTitleColorOnly() {
-        let controlState = Normal(.red)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(.red)
+        assertButton(with: controlStateStyle)
     }
     
     func testControlStateInitializerBorderColorOnly() {
-        let controlState = Normal(borderColor: .red)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(borderColor: .red)
+        assertButton(with: controlStateStyle)
     }
     
     func testControlStateInitializerTitleAndTitleColor() {
-        let controlState = Normal(fooText, .red)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(fooText, .red)
+        assertButton(with: controlStateStyle)
     }
 
     func testControlStateInitializerTitleAndTitleColorAndBorderColor() {
-        let controlState = Normal(fooText, .red, borderColor: .blue)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(fooText, titleColor: .red, borderColor: .blue)
+        assertButton(with: controlStateStyle)
     }
     
     func testControlStateInitializerTitleAndImage() {
-        let controlState = Normal(fooText, image)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(fooText, image)
+        assertButton(with: controlStateStyle)
     }
 
     func testControlStateInitializerTitleAndTitleColorAndImage() {
-        let controlState = Normal(fooText, .red, image)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(fooText, image, .red)
+        assertButton(with: controlStateStyle)
     }
     
     func testControlStateInitializerTitleAndTitleColorAndImageAndBorderColor() {
-        let controlState = Normal(fooText, .red, image, borderColor: .blue)
-        assertButton(with: controlState)
+        let controlStateStyle = Normal(fooText, image: image, titleColor: .red, borderColor: .blue)
+        assertButton(with: controlStateStyle)
     }
     
-    private func assertButton(with state: ControlState) {
-        let button: UIButton = [.states([state])]
-        if let title = state.title {
-            assertIs(button.title(for: state.state), is: title)
+    private func assertButton(with style: ControlStateStyle) {
+        let button: UIButton = [.states([style])]
+        let state = style.state
+        if let title = style.title {
+            assertIs(button.title(for: state), is: title)
         }
-        if let titleColor = state.titleColor {
-            assertIs(button.titleColor(for: state.state), is: titleColor)
+        if let titleColor = style.titleColor {
+            assertIs(button.titleColor(for: state), is: titleColor)
         }
-        if let image = state.image {
-            assertIs(button.image(for: state.state), is: image)
+        if let image = style.image {
+            assertIs(button.image(for: state), is: image)
         }
-        if let borderColor = state.borderColor, state.state == .normal {
+        if let borderColor = style.borderColor, state == .normal {
             assertIs(button.layer.borderColor, is: borderColor.cgColor)
         }
     }


### PR DESCRIPTION
Fixed bug where Placeholder was not set on `UITextField` or `UISearchBar`, sorry bout that!

Adding missing merge functions between two arrays of `Attribute`, i.e. `[Attributed.Attribute]` merges with  `[Attributed.Attribute]`, resulting in  `Attributed`, or `Makeable` or `Composable`.
Renaming `ControlState` to `ControlStateStyle` which it actually is.
Changed order in which Attributes are applied to `ViewStyle`, starting with shared ones (`UIView` attributes) and finishing with specific ones, thus removing need for postmake setup in e.g. `UIButton` (which has been removed).`
Adding support for different background colors on `UIButton`s depending on state, represented in `ControlStateStyle` (previous: `ControlState`), the background is setup using colorToImage and setImage, if ControlStateStyle has an image, then only that image is used.